### PR TITLE
Fix log prob underflow in worker

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -68,7 +68,7 @@ def worker(worker_id: int,
                 else:
                     advantage = reward_t + gamma * next_value - value
 
-                policy_loss = -torch.log(probs[0, action_idx]) * advantage.detach()
+                policy_loss = -torch.log(probs[0, action_idx] + 1e-8) * advantage.detach()
                 value_loss = advantage.pow(2)
                 loss = policy_loss + value_loss
                 


### PR DESCRIPTION
## Summary
- prevent log of zero probability in `worker.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c2d0911a08328bb3b1a0d3c8167ff