### PR TITLE
Remove Trade.just_closed_profit

### DIFF
--- a/live_env.py
+++ b/live_env.py
@@ -22,7 +22,6 @@ class Trade:
         self.exit_price = exit_price
         self.profit = profit
         self.timestamp = timestamp
-        self.just_closed_profit = None  # <--- NEW
 
     def __repr__(self):
         return (


### PR DESCRIPTION
## Summary
- remove per-Trade `just_closed_profit` attribute
- rely on environment level attribute for closed trade P/L tracking

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c2d069f688328be76260e249d6371