### PR TITLE
Add global seed helper

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,11 @@
 # config.py
 # Base trading configuration
 import os
+import random
+from typing import Optional
+
+import numpy as np
+import torch
 
 class TradingConfig:
     GRANULARITY = "H1"
@@ -17,6 +22,13 @@ except ImportError:
     DEFAULT_ACCOUNT_ID = os.getenv("OANDA_ACCOUNT_ID")
     DEFAULT_ACCESS_TOKEN = os.getenv("OANDA_ACCESS_TOKEN")
     DEFAULT_ENVIRONMENT = os.getenv("OANDA_ENVIRONMENT", "practice")
+
+
+def set_global_seed(seed: int) -> None:
+    """Seed random number generators for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
 
 class CurrencyConfig:
     def __init__(self, instrument, live_units, simulated_units, spread, account_id, access_token, environment):

--- a/main_WEEKEND.py
+++ b/main_WEEKEND.py
@@ -1,11 +1,12 @@
 import os
+import argparse
 import threading
 import torch
 import torch.optim as optim
 
 from models import ActorCritic
 from worker import worker
-from config import CURRENCY_CONFIGS, TradingConfig
+from config import CURRENCY_CONFIGS, TradingConfig, set_global_seed
 from simulated_env import SimulatedOandaForexEnv
 
 
@@ -82,6 +83,24 @@ def evaluate_model(model, currency_config, episodes: int = 3, steps: int = 50):
 MODEL_DIR = "./models/"
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Random seed for reproducibility",
+    )
+    args = parser.parse_args()
+    seed = args.seed
+    if seed is None:
+        env_seed = os.getenv("SEED")
+        if env_seed is not None:
+            try:
+                seed = int(env_seed)
+            except ValueError:
+                seed = None
+    if seed is not None:
+        set_global_seed(seed)
+
     # Set training parameters for the weekend training script.
     num_workers = 200       # Use 100 worker threads.
     train_steps = 121      # Each worker runs 121 training steps.


### PR DESCRIPTION
## Summary
- add `set_global_seed` helper to `config.py`
- seed random generators when running `main.py` and `main_WEEKEND.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c2d097ae08328bf080887b4724634