### PR TITLE
Enable concurrent worker threads

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,8 +9,7 @@ import torch
 
 class TradingConfig:
     GRANULARITY = "H1"
-    # CANDLE_COUNT = 5000
-    CANDLE_COUNT = 136
+    CANDLE_COUNT = 5000
 
 try:
     from local_config import (

--- a/main.py
+++ b/main.py
@@ -104,14 +104,13 @@ def run_training_cycle(models, num_workers, train_steps, training_label):
         print(f"\n--- {training_label} Training cycle for {currency} ---")
         model = models[currency]
         optimizer = optim.Adam(model.parameters(), lr=0.00004)
-        optimizer_lock = threading.Lock()
         barrier = threading.Barrier(num_workers + 1)
         
         workers = []
         for i in range(num_workers):
             t = threading.Thread(
                 target=worker,
-                args=(i, model, optimizer, optimizer_lock, train_steps, currency_config, barrier),
+                args=(i, model, optimizer, train_steps, currency_config, barrier),
                 daemon=True
             )
             workers.append(t)

--- a/main_WEEKEND.py
+++ b/main_WEEKEND.py
@@ -59,14 +59,13 @@ def main():
         print(f"\n--- Training cycle for {currency} ---")
         model = models[currency]
         optimizer = optim.Adam(model.parameters(), lr=0.00004)
-        optimizer_lock = threading.Lock()
         barrier = threading.Barrier(num_workers + 1)
 
         workers = []
         for i in range(num_workers):
             t = threading.Thread(
                 target=worker,
-                args=(i, model, optimizer, optimizer_lock, train_steps, currency_config, barrier),
+                args=(i, model, optimizer, train_steps, currency_config, barrier),
                 daemon=True
             )
             workers.append(t)


### PR DESCRIPTION
## Summary
- remove optimizer lock from worker threads so they run concurrently
- train using more candle data by setting `TradingConfig.CANDLE_COUNT` to 5000

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ce0459fb483288bae0ef50bbbf6f2