### PR TITLE
Add training action stats and close open positions in evaluation

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -52,6 +52,9 @@ def evaluate_model(
 
             state = torch.tensor(next_state, dtype=torch.float32).unsqueeze(0)
 
+        if env.position_open:
+            env.simulated_close_position()
+
         total_reward += episode_reward
         profits.extend(t.profit for t in env.trade_log)
         total_trades += len(env.trade_log)


### PR DESCRIPTION
## Summary
- close remaining positions at the end of evaluation episodes
- track actions taken during training
- print training action distribution after each cycle in main scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d260a4fa0832890f6056cadebe4fd