### PR TITLE
Add model locking for worker threads

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,15 +111,24 @@ def run_training_cycle(models, num_workers, train_steps, training_label):
         barrier = threading.Barrier(num_workers + 1)
         action_counts = [0, 0, 0]
         action_lock = threading.Lock()
+        model_lock = threading.Lock()
 
         workers = []
         for i in range(num_workers):
             t = threading.Thread(
                 target=worker,
-                args=(i, model, optimizer, train_steps, currency_config, barrier),
+                args=(
+                    i,
+                    model,
+                    optimizer,
+                    train_steps,
+                    currency_config,
+                    barrier,
+                ),
                 kwargs={
                     "action_counts": action_counts,
                     "action_lock": action_lock,
+                    "model_lock": model_lock,
                 },
                 daemon=True
             )

--- a/main_WEEKEND.py
+++ b/main_WEEKEND.py
@@ -62,15 +62,24 @@ def main():
         barrier = threading.Barrier(num_workers + 1)
         action_counts = [0, 0, 0]
         action_lock = threading.Lock()
+        model_lock = threading.Lock()
 
         workers = []
         for i in range(num_workers):
             t = threading.Thread(
                 target=worker,
-                args=(i, model, optimizer, train_steps, currency_config, barrier),
+                args=(
+                    i,
+                    model,
+                    optimizer,
+                    train_steps,
+                    currency_config,
+                    barrier,
+                ),
                 kwargs={
                     "action_counts": action_counts,
                     "action_lock": action_lock,
+                    "model_lock": model_lock,
                 },
                 daemon=True
             )


### PR DESCRIPTION
## Summary
- add `model_lock` parameter to `worker`
- document `model_lock` usage
- guard updates with `with model_lock:`
- create and pass `model_lock` when launching workers in `main.py` and `main_WEEKEND.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d68d9547c83288068d2ecec93ea1a