### PR TITLE
Encode decision history as one-hot vectors

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -2,6 +2,8 @@ import torch
 from typing import Tuple
 from collections import deque
 
+from preprocessing import encode_decision_history
+
 from models import ActorCritic
 from simulated_env import SimulatedOandaForexEnv
 from config import TradingConfig
@@ -35,8 +37,8 @@ def evaluate_model(
 
     for _ in range(episodes):
         state = torch.tensor(env.reset(), dtype=torch.float32).unsqueeze(0)
-        decision_history = deque([0] * 16, maxlen=16)
-        decisions = torch.tensor(decision_history, dtype=torch.float32).unsqueeze(0)
+        decision_history = deque([2] * 16, maxlen=16)
+        decisions = encode_decision_history(decision_history)
         episode_reward = 0.0
         done = False
         while not done:
@@ -48,7 +50,7 @@ def evaluate_model(
             action_counts[action] += 1
             next_state, reward, done, _ = env.step(action)
             decision_history.append(action)
-            decisions = torch.tensor(decision_history, dtype=torch.float32).unsqueeze(0)
+            decisions = encode_decision_history(decision_history)
             episode_reward += reward
 
             if done or next_state is None:
@@ -126,8 +128,8 @@ def feature_importance(model: ActorCritic, currency_config, episodes: int = 3):
 
     for _ in range(episodes):
         state = torch.tensor(env.reset(), dtype=torch.float32).unsqueeze(0)
-        decision_history = deque([0] * 16, maxlen=16)
-        decisions = torch.tensor(decision_history, dtype=torch.float32).unsqueeze(0)
+        decision_history = deque([2] * 16, maxlen=16)
+        decisions = encode_decision_history(decision_history)
         done = False
 
         while not done:
@@ -147,7 +149,7 @@ def feature_importance(model: ActorCritic, currency_config, episodes: int = 3):
 
             next_state, _, done, _ = env.step(action.item())
             decision_history.append(action.item())
-            decisions = torch.tensor(decision_history, dtype=torch.float32).unsqueeze(0)
+            decisions = encode_decision_history(decision_history)
             if done or next_state is None:
                 break
             state = torch.tensor(next_state, dtype=torch.float32).unsqueeze(0)

--- a/main.py
+++ b/main.py
@@ -8,6 +8,8 @@ import torch
 import torch.optim as optim
 from collections import deque
 
+from preprocessing import encode_decision_history
+
 import tg_bot  # Contains Telegram bot logic and global "last_trade_status"
 from models import ActorCritic
 from worker import worker
@@ -72,8 +74,8 @@ def trade_live(currency_model, live_env, num_steps=10):
     """
     currency_model.eval()
     state = live_env.reset()
-    decision_history = deque([0] * 16, maxlen=16)
-    decisions = torch.tensor(decision_history, dtype=torch.float32).unsqueeze(0)
+    decision_history = deque([2] * 16, maxlen=16)
+    decisions = encode_decision_history(decision_history)
     state = torch.tensor(state, dtype=torch.float32).unsqueeze(0)
     
     for step in range(num_steps):
@@ -84,7 +86,7 @@ def trade_live(currency_model, live_env, num_steps=10):
         print(f"[Trading] Step {step}, Action: {action}")
         next_state, reward, done, _ = live_env.step(action)
         decision_history.append(action)
-        decisions = torch.tensor(decision_history, dtype=torch.float32).unsqueeze(0)
+        decisions = encode_decision_history(decision_history)
         print(f"[Trading] Reward: {reward}")
         if not done and next_state is not None:
             state = torch.tensor(next_state, dtype=torch.float32).unsqueeze(0)

--- a/models.py
+++ b/models.py
@@ -6,8 +6,19 @@ import torch.nn.functional as F
 
 
 class ActorCritic(nn.Module):
-    def __init__(self, input_size=7, decision_dim=16, hidden_size=128, num_actions=3, num_lstm_layers=4):
-        super(ActorCritic, self).__init__()
+    """Combined actor-critic network."""
+
+    def __init__(
+        self,
+        input_size: int = 7,
+        decision_history_len: int = 16,
+        hidden_size: int = 128,
+        num_actions: int = 3,
+        num_lstm_layers: int = 4,
+    ) -> None:
+        """Initialize the network."""
+        super().__init__()
+        decision_dim = decision_history_len * num_actions
         # Actor branch with a deeper LSTM (2 layers)
         self.actor_lstm = nn.LSTM(input_size, hidden_size, num_layers=num_lstm_layers, batch_first=True)
         self.actor_fc1 = nn.Linear(hidden_size, 32)
@@ -22,7 +33,8 @@ class ActorCritic(nn.Module):
         self.critic_fc3 = nn.Linear(64, 64)
         self.critic_output = nn.Linear(64, 1)
         
-    def forward(self, state, decisions):
+    def forward(self, state: torch.Tensor, decisions: torch.Tensor):
+        """Return policy logits and state-value estimate."""
         # Actor forward pass
         actor_out, _ = self.actor_lstm(state)
         actor_last = actor_out[:, -1, :]  # Take output of the final time step

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -1,0 +1,23 @@
+import torch
+import torch.nn.functional as F
+from typing import Iterable
+
+
+def encode_decision_history(history: Iterable[int], num_actions: int = 3) -> torch.Tensor:
+    """Return a one-hot encoded tensor for a sequence of past actions.
+
+    Parameters
+    ----------
+    history : iterable of int
+        Sequence of past actions.
+    num_actions : int, optional
+        Number of discrete actions. Defaults to ``3``.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor with shape ``(1, len(history) * num_actions)``.
+    """
+    hist = torch.tensor(list(history), dtype=torch.long)
+    one_hot = F.one_hot(hist, num_classes=num_actions).float()
+    return one_hot.view(1, -1)

--- a/worker.py
+++ b/worker.py
@@ -3,6 +3,8 @@ import numpy as np
 import traceback
 from collections import deque
 
+from preprocessing import encode_decision_history
+
 from simulated_env import SimulatedOandaForexEnv
 from models import ActorCritic
 from config import TradingConfig
@@ -63,18 +65,15 @@ def worker(
     
     # Get the initial state and initialize decision history.
     state = env.reset()  # Expected shape: (time_window, features)
-    decision_history = deque([0] * 16, maxlen=16)
-    decisions = np.array(decision_history, dtype=np.float32).reshape(1, -1)
+    decision_history = deque([2] * 16, maxlen=16)
+    decisions_t = encode_decision_history(decision_history)
     state_t = torch.tensor(state, dtype=torch.float32).unsqueeze(0)
     
     step_count = 0
     returns = torch.tensor([[0.0]], dtype=torch.float32)
     while step_count < max_steps:
         try:
-            decisions = np.array(decision_history, dtype=np.float32).reshape(
-                1, -1
-            )
-            decisions_t = torch.tensor(decisions, dtype=torch.float32)
+            decisions_t = encode_decision_history(decision_history)
             with model_lock:
                 policy_logits, value = global_model(state_t, decisions_t)
                 probs = torch.softmax(policy_logits, dim=1)
@@ -122,7 +121,7 @@ def worker(
             # Update the state and history.
             if done or next_state is None:
                 state = env.reset()
-                decision_history = deque([0] * 16, maxlen=16)
+                decision_history = deque([2] * 16, maxlen=16)
                 returns[:] = 0
             else:
                 state = next_state
@@ -144,10 +143,7 @@ def worker(
         profit = env.simulated_close_position()
         if profit is not None:
             final_reward = float(np.clip(profit, -1.0, 1.0))
-            decisions = np.array(
-                decision_history, dtype=np.float32
-            ).reshape(1, -1)
-            decisions_t = torch.tensor(decisions, dtype=torch.float32)
+            decisions_t = encode_decision_history(decision_history)
             reward_t = torch.tensor([[final_reward]], dtype=torch.float32)
             with model_lock:
                 _, value = global_model(state_t, decisions_t)


### PR DESCRIPTION
## Summary
- add helper `encode_decision_history`
- update ActorCritic to accept one-hot decision history
- preprocess decision history in training, evaluation and live trading

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d6e07faac8328b746f88e89ed2708