### PR TITLE
Adjust reward scaling and enable accumulated returns

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,6 +10,9 @@ import torch
 class TradingConfig:
     GRANULARITY = "H1"
     CANDLE_COUNT = 5000
+    # Factor applied to raw profit when computing rewards. This helps
+    # emphasize profitable trades relative to the neutral action.
+    REWARD_SCALE = 5.0
 
 try:
     from local_config import (

--- a/live_env.py
+++ b/live_env.py
@@ -243,7 +243,7 @@ class LiveOandaForexEnv:
         """
         # 1) If a position was closed this step, immediately return that realized P&L.
         if self.just_closed_profit is not None:
-            reward = self.just_closed_profit
+            reward = self.just_closed_profit * TradingConfig.REWARD_SCALE
             self.just_closed_profit = None
             return float(np.clip(reward, -1.0, 1.0))
         
@@ -251,10 +251,14 @@ class LiveOandaForexEnv:
         if self.position_open:
             current_price = self.data[self.current_index][3]
             if self.position_side == "long":
-                reward = (current_price - self.entry_price) / self.entry_price
+                reward = (
+                    (current_price - self.entry_price) / self.entry_price
+                ) * TradingConfig.REWARD_SCALE
                 return float(np.clip(reward, -1.0, 1.0))
             else:  # short
-                reward = (self.entry_price - current_price) / self.entry_price
+                reward = (
+                    (self.entry_price - current_price) / self.entry_price
+                ) * TradingConfig.REWARD_SCALE
                 return float(np.clip(reward, -1.0, 1.0))
         
         # 3) No open position and no just-closed position => zero reward

--- a/main.py
+++ b/main.py
@@ -131,6 +131,7 @@ def run_training_cycle(models, num_workers, train_steps, training_label):
                     "action_counts": action_counts,
                     "action_lock": action_lock,
                     "model_lock": model_lock,
+                    "accumulate_returns": True,
                 },
                 daemon=True
             )

--- a/simulated_env.py
+++ b/simulated_env.py
@@ -124,17 +124,21 @@ class SimulatedOandaForexEnv:
         3) Otherwise return 0.
         """
         if self.just_closed_profit is not None:
-            reward = self.just_closed_profit
+            reward = self.just_closed_profit * TradingConfig.REWARD_SCALE
             self.just_closed_profit = None
             return float(np.clip(reward, -1.0, 1.0))
 
         if self.position_open:
             current_price = self.data[self.current_index][3]
             if self.position_side == "long":
-                reward = (current_price - self.entry_price) / self.entry_price
+                reward = (
+                    (current_price - self.entry_price) / self.entry_price
+                ) * TradingConfig.REWARD_SCALE
                 return float(np.clip(reward, -1.0, 1.0))
             else:
-                reward = (self.entry_price - current_price) / self.entry_price
+                reward = (
+                    (self.entry_price - current_price) / self.entry_price
+                ) * TradingConfig.REWARD_SCALE
                 return float(np.clip(reward, -1.0, 1.0))
 
         return 0.0


### PR DESCRIPTION
## Summary
- add `REWARD_SCALE` constant to `TradingConfig`
- scale mark-to-market and realized rewards in both envs
- pass `accumulate_returns=True` to worker threads

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e126cfe78832890818e921e64f875