### PR TITLE
Add entropy regularization to training worker

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,6 +132,7 @@ def run_training_cycle(models, num_workers, train_steps, training_label):
                     "action_lock": action_lock,
                     "model_lock": model_lock,
                     "accumulate_returns": True,
+                    "entropy_weight": 0.01,
                 },
                 daemon=True
             )

--- a/main_WEEKEND.py
+++ b/main_WEEKEND.py
@@ -95,6 +95,7 @@ def main():
                     "action_counts": action_counts,
                     "action_lock": action_lock,
                     "model_lock": model_lock,
+                    "entropy_weight": 0.01,
                 },
                 daemon=True
             )


### PR DESCRIPTION
## Summary
- encourage exploration by regularizing policy entropy in `worker`
- expose entropy weight parameter through `main.py` and `main_WEEKEND.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e211a59a08328a256061ef2a9718e