### PR TITLE
Expose reward clipping values in config

### DIFF
--- a/config.py
+++ b/config.py
@@ -12,7 +12,11 @@ class TradingConfig:
     CANDLE_COUNT = 5000
     # Factor applied to raw profit when computing rewards. This helps
     # emphasize profitable trades relative to the neutral action.
-    REWARD_SCALE = 5.0
+    REWARD_SCALE = 10.0
+    # Minimum reward value after clipping
+    REWARD_CLIP_LOW = -2.0
+    # Maximum reward value after clipping
+    REWARD_CLIP_HIGH = 2.0
 
 try:
     from local_config import (

--- a/live_env.py
+++ b/live_env.py
@@ -245,7 +245,13 @@ class LiveOandaForexEnv:
         if self.just_closed_profit is not None:
             reward = self.just_closed_profit * TradingConfig.REWARD_SCALE
             self.just_closed_profit = None
-            return float(np.clip(reward, -1.0, 1.0))
+            return float(
+                np.clip(
+                    reward,
+                    TradingConfig.REWARD_CLIP_LOW,
+                    TradingConfig.REWARD_CLIP_HIGH,
+                )
+            )
         
         # 2) If a position is still open, compute mark-to-market.
         if self.position_open:
@@ -254,12 +260,24 @@ class LiveOandaForexEnv:
                 reward = (
                     (current_price - self.entry_price) / self.entry_price
                 ) * TradingConfig.REWARD_SCALE
-                return float(np.clip(reward, -1.0, 1.0))
+                return float(
+                    np.clip(
+                        reward,
+                        TradingConfig.REWARD_CLIP_LOW,
+                        TradingConfig.REWARD_CLIP_HIGH,
+                    )
+                )
             else:  # short
                 reward = (
                     (self.entry_price - current_price) / self.entry_price
                 ) * TradingConfig.REWARD_SCALE
-                return float(np.clip(reward, -1.0, 1.0))
+                return float(
+                    np.clip(
+                        reward,
+                        TradingConfig.REWARD_CLIP_LOW,
+                        TradingConfig.REWARD_CLIP_HIGH,
+                    )
+                )
         
         # 3) No open position and no just-closed position => zero reward
         return 0.0

--- a/simulated_env.py
+++ b/simulated_env.py
@@ -126,7 +126,13 @@ class SimulatedOandaForexEnv:
         if self.just_closed_profit is not None:
             reward = self.just_closed_profit * TradingConfig.REWARD_SCALE
             self.just_closed_profit = None
-            return float(np.clip(reward, -1.0, 1.0))
+            return float(
+                np.clip(
+                    reward,
+                    TradingConfig.REWARD_CLIP_LOW,
+                    TradingConfig.REWARD_CLIP_HIGH,
+                )
+            )
 
         if self.position_open:
             current_price = self.data[self.current_index][3]
@@ -134,12 +140,24 @@ class SimulatedOandaForexEnv:
                 reward = (
                     (current_price - self.entry_price) / self.entry_price
                 ) * TradingConfig.REWARD_SCALE
-                return float(np.clip(reward, -1.0, 1.0))
+                return float(
+                    np.clip(
+                        reward,
+                        TradingConfig.REWARD_CLIP_LOW,
+                        TradingConfig.REWARD_CLIP_HIGH,
+                    )
+                )
             else:
                 reward = (
                     (self.entry_price - current_price) / self.entry_price
                 ) * TradingConfig.REWARD_SCALE
-                return float(np.clip(reward, -1.0, 1.0))
+                return float(
+                    np.clip(
+                        reward,
+                        TradingConfig.REWARD_CLIP_LOW,
+                        TradingConfig.REWARD_CLIP_HIGH,
+                    )
+                )
 
         return 0.0
 

--- a/worker.py
+++ b/worker.py
@@ -147,7 +147,13 @@ def worker(
     if env.position_open:
         profit = env.simulated_close_position()
         if profit is not None:
-            final_reward = float(np.clip(profit, -1.0, 1.0))
+            final_reward = float(
+                np.clip(
+                    profit,
+                    TradingConfig.REWARD_CLIP_LOW,
+                    TradingConfig.REWARD_CLIP_HIGH,
+                )
+            )
             decisions_t = encode_decision_history(decision_history)
             reward_t = torch.tensor([[final_reward]], dtype=torch.float32)
             with model_lock:


### PR DESCRIPTION
## Summary
- add `REWARD_CLIP_LOW` and `REWARD_CLIP_HIGH` to `TradingConfig`
- clamp rewards in envs and worker using config values
- widen reward range and increase scaling factor

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from models import ActorCritic
from config import CURRENCY_CONFIGS, set_global_seed
from evaluation import evaluate_model
set_global_seed(0)
model = ActorCritic()
currency_config = CURRENCY_CONFIGS['EUR_USD']
avg_reward, avg_profit, win_rate = evaluate_model(model, currency_config, episodes=1, candle_count=100)
print(avg_reward, avg_profit, win_rate)
PY` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684e2944f7888328b4df64b18eaa8a6a