### PR TITLE
Add RSI feature

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -112,7 +112,7 @@ def feature_importance(model: ActorCritic, currency_config, episodes: int = 3):
     greedily selects actions from the policy. For each step the gradient of the
     selected action's logit with respect to the input state is computed. The
     absolute gradients are accumulated and averaged across all steps and
-    episodes. The resulting importances for the seven input features are
+    episodes. The resulting importances for the eight input features are
     normalized to sum to one.
     """
 
@@ -123,7 +123,7 @@ def feature_importance(model: ActorCritic, currency_config, episodes: int = 3):
     )
 
     model.eval()
-    importance = torch.zeros(7)
+    importance = torch.zeros(8)
     step_count = 0
 
     for _ in range(episodes):

--- a/feature_extractor.py
+++ b/feature_extractor.py
@@ -1,29 +1,85 @@
 import numpy as np
 
+
+def compute_rsi(closes, period=15):
+    """Return the Relative Strength Index for ``closes``.
+
+    Parameters
+    ----------
+    closes : array-like
+        Sequence of close prices.
+    period : int, optional
+        Number of periods to use for RSI calculation. Defaults to ``15``.
+
+    Returns
+    -------
+    np.ndarray
+        Array of RSI values aligned with ``closes``.
+    """
+    closes = np.asarray(closes, dtype=np.float64)
+    deltas = np.diff(closes)
+    gains = np.where(deltas > 0, deltas, 0.0)
+    losses = np.where(deltas < 0, -deltas, 0.0)
+
+    rsi = np.full(closes.shape, 50.0, dtype=np.float64)
+    if closes.size <= period:
+        return rsi
+
+    avg_gain = gains[:period].mean()
+    avg_loss = losses[:period].mean()
+    rs = avg_gain / avg_loss if avg_loss != 0 else np.inf
+    rsi[period] = 100.0 - 100.0 / (1.0 + rs)
+
+    for i in range(period + 1, closes.size):
+        delta = deltas[i - 1]
+        gain = max(delta, 0.0)
+        loss = -min(delta, 0.0)
+        avg_gain = (avg_gain * (period - 1) + gain) / period
+        avg_loss = (avg_loss * (period - 1) + loss) / period
+        rs = avg_gain / avg_loss if avg_loss != 0 else np.inf
+        rsi[i] = 100.0 - 100.0 / (1.0 + rs)
+
+    return rsi
+
 def compute_features(data):
+    """Return feature matrix derived from OHLCV data.
+
+    For each time step ``i`` (starting at 1) the following features are
+    computed:
+
+    ``x1``  Percentage change in close price.
+    ``x2``  Percentage change in high price.
+    ``x3``  Percentage change in low price.
+    ``x4``  Relative difference between high and close.
+    ``x5``  Relative difference between close and low.
+    ``x6``  Actual spread computed from bid/ask prices.
+    ``x7``  15-period RSI of the close price.
+
+    Parameters
+    ----------
+    data : array-like
+        Array of candles ``[open, high, low, close, volume, spread]``.
+
+    Returns
+    -------
+    np.ndarray
+        Array with shape ``(len(data)-1, 7)`` containing the features.
     """
-    Compute features for each time step from the OHLC data with actual spread.
-    For each time step i (starting at 1):
-      x1 = (c_i - c_{i-1}) / c_{i-1}      : % change in close price
-      x2 = (h_i - h_{i-1}) / h_{i-1}      : % change in high price
-      x3 = (l_i - l_{i-1}) / l_{i-1}      : % change in low price
-      x4 = (h_i - c_i) / c_i              : Relative difference between high and close
-      x5 = (c_i - l_i) / c_i              : Relative difference between close and low
-      x6 = actual spread                  : Spread computed from bid/ask prices
-    
-    Returns:
-      A NumPy array of shape (len(data)-1, 6)
-    """
+
+    closes = [c[3] for c in data]
+    rsi_values = compute_rsi(closes, period=15)
+
     features = []
     for i in range(1, len(data)):
-        # Use previous candle for price comparisons; ignore volume and spread.
-        _, h_prev, l_prev, c_prev, _, _ = data[i-1]
-        o, h, l, c, _, spread = data[i]
+        _, h_prev, l_prev, c_prev, _, _ = data[i - 1]
+        _, h, l, c, _, spread = data[i]
         x1 = (c - c_prev) / c_prev
         x2 = (h - h_prev) / h_prev
         x3 = (l - l_prev) / l_prev
-        x4 = (h - c) / c if c != 0 else 0
-        x5 = (c - l) / c if c != 0 else 0
+        x4 = (h - c) / c if c != 0 else 0.0
+        x5 = (c - l) / c if c != 0 else 0.0
         x6 = spread
-        features.append([x1, x2, x3, x4, x5, x6])
+        x7 = rsi_values[i]
+        features.append([x1, x2, x3, x4, x5, x6, x7])
+
     return np.array(features)

--- a/live_env.py
+++ b/live_env.py
@@ -309,7 +309,7 @@ class LiveOandaForexEnv:
         # Update live data (this updates self.data and self.features, and increments self.current_index)
         self.update_live_data()
         
-        # Prepare the next state: a sliding window of 16 rows of features (each originally 12 dimensions)
+        # Prepare the next state: a sliding window of 16 rows of features (each originally 7 dimensions)
         next_features = self.features[self.current_index-16:self.current_index]
         next_features = self.scaler.normalize(next_features)
         
@@ -328,7 +328,7 @@ class LiveOandaForexEnv:
         # Append the P/L as an extra feature column to each row in the sliding window
         # This creates a column with shape (16, 1) filled with current_pl.
         pl_column = np.full((next_features.shape[0], 1), current_pl)
-        # Concatenate horizontally to obtain an updated state with 13 features per timestep.
+        # Concatenate horizontally to obtain an updated state with 8 features per timestep.
         next_state = np.hstack((next_features, pl_column))
         
         done = False  # Live trading typically runs continuously

--- a/models.py
+++ b/models.py
@@ -10,7 +10,7 @@ class ActorCritic(nn.Module):
 
     def __init__(
         self,
-        input_size: int = 7,
+        input_size: int = 8,
         decision_history_len: int = 16,
         hidden_size: int = 128,
         num_actions: int = 3,

--- a/simulated_env.py
+++ b/simulated_env.py
@@ -77,8 +77,8 @@ class SimulatedOandaForexEnv:
     def reset(self):
         """
         Reset the environment to its initial state.
-        Returns a state with shape (16, 7):
-          - 6 features from compute_features (x1–x6)
+        Returns a state with shape (16, 8):
+          - 7 features from compute_features (x1–x7)
           - 1 additional column for P/L (set to 0)
         """
         self.current_index = 16
@@ -93,7 +93,7 @@ class SimulatedOandaForexEnv:
         base_features = self.scaler.normalize(base_features)
         current_pl = 0.0
         pl_column = np.full((base_features.shape[0], 1), current_pl)  # Shape: (16, 1)
-        state_with_pl = np.hstack((base_features, pl_column))  # Final shape: (16, 7)
+        state_with_pl = np.hstack((base_features, pl_column))  # Final shape: (16, 8)
         return state_with_pl
 
     def update_live_data(self):
@@ -198,7 +198,7 @@ class SimulatedOandaForexEnv:
         """
         Execute one step in the simulated trading environment.
         Returns:
-          next_state: (16, 7) array,
+          next_state: (16, 8) array,
           reward: float,
           done: bool,
           info: dict


### PR DESCRIPTION
## Summary
- compute 15-period RSI and return as extra feature
- adjust model input and environments for new 8-feature states
- update evaluation utility to handle eight features

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e3f9fb67c83289bd095d26e7c2226