### PR TITLE
Fix checkpoint loading for model input size mismatch

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from collections import deque
 from preprocessing import encode_decision_history
 
 import tg_bot  # Contains Telegram bot logic and global "last_trade_status"
-from models import ActorCritic
+from models import ActorCritic, load_checkpoint
 from worker import worker
 from live_env import LiveOandaForexEnv
 from config import TradingConfig, CURRENCY_CONFIGS, set_global_seed
@@ -180,7 +180,7 @@ def trading_loop(train_steps_full=121):
         currency_model = ActorCritic()
         if os.path.exists(model_path):
             try:
-                currency_model.load_state_dict(torch.load(model_path))
+                load_checkpoint(currency_model, model_path)
                 print(f"Loaded existing model for {currency}.")
             except Exception as e:
                 print(
@@ -217,7 +217,7 @@ def trading_loop(train_steps_full=121):
                     model_path = os.path.join(MODEL_DIR, f"{currency}.pt")
                     if os.path.exists(model_path):
                         try:
-                            models[currency].load_state_dict(torch.load(model_path))
+                            load_checkpoint(models[currency], model_path)
                             print(f"Reloaded latest model for {currency}.")
                         except Exception as e:
                             print(

--- a/main_WEEKEND.py
+++ b/main_WEEKEND.py
@@ -6,7 +6,7 @@ import torch.optim as optim
 
 from tg_bot import send_telegram_message
 
-from models import ActorCritic
+from models import ActorCritic, load_checkpoint
 from worker import worker
 from config import CURRENCY_CONFIGS, set_global_seed
 from evaluation import evaluate_model, feature_importance
@@ -62,8 +62,14 @@ def main():
         model_path = os.path.join(MODEL_DIR, f"{currency}.pt")
         currency_model = ActorCritic()
         if os.path.exists(model_path):
-            currency_model.load_state_dict(torch.load(model_path))
-            print(f"Loaded existing model for {currency}.")
+            try:
+                load_checkpoint(currency_model, model_path)
+                print(f"Loaded existing model for {currency}.")
+            except Exception as e:
+                print(
+                    f"Failed to load model for {currency}: {e}. "
+                    "Initializing a new model instead."
+                )
         else:
             print(f"Initializing new model for {currency}.")
         currency_model.share_memory()


### PR DESCRIPTION
## Summary
- add `load_checkpoint` helper to patch older models
- use new loader in main scripts so outdated checkpoints don't crash training

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e40d0413083289879691a65e4e529