### PR TITLE
Align live trading action selection with evaluation

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ def trade_live(currency_model, live_env, num_steps=10):
         with torch.no_grad():
             policy_logits, _ = currency_model(state, decisions)
             probs = torch.softmax(policy_logits, dim=1)
-            action = torch.multinomial(probs, num_samples=1).item()
+            action = torch.argmax(probs, dim=1).item()
         print(f"[Trading] Step {step}, Action: {action}")
         next_state, reward, done, _ = live_env.step(action)
         decision_history.append(action)


### PR DESCRIPTION
## Summary
- use greedy action selection in `trade_live`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f5bf9dfdc8328a009b70d23074853