### PR TITLE
Switch trading to minute data

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,7 +8,8 @@ import numpy as np
 import torch
 
 class TradingConfig:
-    GRANULARITY = "H1"
+    GRANULARITY = "H1"  # Used for training and evaluation
+    TRADING_GRANULARITY = "M1"  # Use minute data when trading live
     CANDLE_COUNT = 5000
     # Factor applied to raw profit when computing rewards. This helps
     # emphasize profitable trades relative to the neutral action.

--- a/live_env.py
+++ b/live_env.py
@@ -32,7 +32,14 @@ class Trade:
         )
 
 class LiveOandaForexEnv:
-    def __init__(self, currency_config, candle_count=TradingConfig.CANDLE_COUNT, granularity=TradingConfig.GRANULARITY):
+    """Environment for live trading using OANDA data."""
+
+    def __init__(
+        self,
+        currency_config,
+        candle_count=TradingConfig.CANDLE_COUNT,
+        granularity=TradingConfig.TRADING_GRANULARITY,
+    ):
         self.account_id = currency_config.account_id
         self.access_token = currency_config.access_token
         self.environment = currency_config.environment

--- a/main.py
+++ b/main.py
@@ -277,7 +277,7 @@ def trading_loop(train_steps_full=121, entropy_weight=0.01):
                     live_env = LiveOandaForexEnv(
                         currency_config,
                         candle_count=TradingConfig.CANDLE_COUNT,
-                        granularity=TradingConfig.GRANULARITY
+                        granularity=TradingConfig.TRADING_GRANULARITY
                     )
                     trade_live(model, live_env, num_steps=trade_steps)
                     print(f"--- Finished trading cycle for {currency} ---")


### PR DESCRIPTION
## Summary
- use minute granularity in live trading
- add TRADING_GRANULARITY constant
- document LiveOandaForexEnv and adjust defaults

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68518349df4c83289cdf2e696f457e3b