### PR TITLE
Use full candle history for live trading

### DIFF
--- a/main.py
+++ b/main.py
@@ -276,7 +276,7 @@ def trading_loop(train_steps_full=121, entropy_weight=0.01):
                     model.eval()
                     live_env = LiveOandaForexEnv(
                         currency_config,
-                        candle_count=16,
+                        candle_count=TradingConfig.CANDLE_COUNT,
                         granularity=TradingConfig.GRANULARITY
                     )
                     trade_live(model, live_env, num_steps=trade_steps)


### PR DESCRIPTION
## Summary
- use TradingConfig.CANDLE_COUNT when instantiating `LiveOandaForexEnv`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68533d9769b88328b2a57d40e2c5e279