### PR TITLE
Fix feature updates and trading granularity

### DIFF
--- a/live_env.py
+++ b/live_env.py
@@ -149,7 +149,9 @@ class LiveOandaForexEnv:
                 environment=self.environment,
             )[0]
             self.data = np.vstack((self.data, candle))
-            new_features = compute_features(self.data[-2:])
+            # Use the last 16 candles when computing features so RSI is
+            # calculated over a full window rather than just two points.
+            new_features = compute_features(self.data[-16:])[-1:]
             self.features = np.vstack((self.features, new_features))
             self.scaler.update(new_features)
             self.current_index += 1

--- a/main.py
+++ b/main.py
@@ -277,7 +277,7 @@ def trading_loop(train_steps_full=121, entropy_weight=0.01):
                     live_env = LiveOandaForexEnv(
                         currency_config,
                         candle_count=TradingConfig.CANDLE_COUNT,
-                        granularity=TradingConfig.GRANULARITY
+                        granularity=TradingConfig.TRADING_GRANULARITY,
                     )
                     trade_live(model, live_env, num_steps=trade_steps)
                     print(f"--- Finished trading cycle for {currency} ---")

--- a/simulated_env.py
+++ b/simulated_env.py
@@ -112,7 +112,9 @@ class SimulatedOandaForexEnv:
             if len(new_candle) != 6:  # Expecting [o, h, l, c, volume, spread]
                 raise ValueError("Invalid candle data returned from OANDA API.")
             self.data = np.vstack((self.data, new_candle))
-            new_features = compute_features(np.vstack((self.data[-2:],)))
+            # Compute features using the last 16 candles to properly
+            # calculate RSI instead of defaulting to a constant value.
+            new_features = compute_features(self.data[-16:])[-1:]
             self.features = np.vstack((self.features, new_features))
             self.scaler.update(new_features)
             self.current_index += 1


### PR DESCRIPTION
## Summary
- use TRADING_GRANULARITY when creating the live environment
- compute new feature rows using the last 16 candles so RSI is calculated over a proper window

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853ee76f6e48328bf5e0872048ca5cc