### PR TITLE
Fix decision history length

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -39,7 +39,8 @@ def evaluate_model(
 
     for _ in range(episodes):
         state = torch.tensor(env.reset(), dtype=torch.float32).unsqueeze(0)
-        decision_history = deque([2] * 16, maxlen=16)
+        hist_len = getattr(model, "decision_history_len", 16)
+        decision_history = deque([2] * hist_len, maxlen=hist_len)
         decisions = encode_decision_history(decision_history)
         episode_reward = 0.0
         steps = 0
@@ -132,7 +133,8 @@ def feature_importance(model: ActorCritic, currency_config, episodes: int = 3):
 
     for _ in range(episodes):
         state = torch.tensor(env.reset(), dtype=torch.float32).unsqueeze(0)
-        decision_history = deque([2] * 16, maxlen=16)
+        hist_len = getattr(model, "decision_history_len", 16)
+        decision_history = deque([2] * hist_len, maxlen=hist_len)
         decisions = encode_decision_history(decision_history)
         done = False
 

--- a/models.py
+++ b/models.py
@@ -18,6 +18,8 @@ class ActorCritic(nn.Module):
     ) -> None:
         """Initialize the network."""
         super().__init__()
+        self.decision_history_len = decision_history_len
+        self.num_actions = num_actions
         decision_dim = decision_history_len * num_actions
         # Actor branch with a deeper LSTM (2 layers)
         self.actor_lstm = nn.LSTM(input_size, hidden_size, num_layers=num_lstm_layers, batch_first=True)

--- a/worker.py
+++ b/worker.py
@@ -71,7 +71,8 @@ def worker(
     
     # Get the initial state and initialize decision history.
     state = env.reset()  # Expected shape: (time_window, features)
-    decision_history = deque([2] * 16, maxlen=16)
+    hist_len = getattr(global_model, "decision_history_len", 16)
+    decision_history = deque([2] * hist_len, maxlen=hist_len)
     decisions_t = encode_decision_history(decision_history)
     state_t = torch.tensor(state, dtype=torch.float32).unsqueeze(0)
     
@@ -129,7 +130,8 @@ def worker(
             # Update the state and history.
             if done or next_state is None:
                 state = env.reset()
-                decision_history = deque([2] * 16, maxlen=16)
+                hist_len = getattr(global_model, "decision_history_len", 16)
+                decision_history = deque([2] * hist_len, maxlen=hist_len)
                 returns[:] = 0
             else:
                 state = next_state


### PR DESCRIPTION
## Summary
- store decision history length in the ActorCritic model
- respect model's history length when initializing `decision_history`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6857484b799c8328a42c43cf9bd65d53